### PR TITLE
feat(table): add method to check if the table is empty

### DIFF
--- a/table.go
+++ b/table.go
@@ -934,3 +934,8 @@ func (t *Table) Render() {
 	t.formatData()
 	t.renderRows()
 }
+
+// IsEmpty returns if the table has no data
+func (t *Table) IsEmpty() bool {
+	return len(t.data) == 0
+}

--- a/table_test.go
+++ b/table_test.go
@@ -814,3 +814,19 @@ func Test_HeaderColSpanTrivyKubernetesStyleFullWithFillWidth(t *testing.T) {
 └──────────────┴──────────────────┴──────────┴──────┴────────┴─────┴─────────┴──────────┴──────┴────────┴──────┴─────────┘
 `, "\n"+builder.String())
 }
+
+func Test_TableIsEmpty(t *testing.T) {
+	builder := &strings.Builder{}
+	table := New(builder)
+	table.SetHeaders("A", "B", "C")
+	assert.Equal(t, true, table.IsEmpty())
+}
+
+func Test_TableIsNotEmpty(t *testing.T) {
+	builder := &strings.Builder{}
+	table := New(builder)
+	table.SetHeaders("A", "B", "C")
+	table.AddRow("1", "2", "3")
+	table.AddRow("4", "5", "6")
+	assert.Equal(t, false, table.IsEmpty())
+}


### PR DESCRIPTION
Add the public method **IsEmpty()** to check if the table has no data.

Example:

```go
t := table.New(os.Stdout)
t.SetHeaders("Key", "Value")
t.AddRow(key, value)

if t.IsEmpty() {
    fmt.Println("No records to show")
} else {
    t.Render()
}
```

This PR resolves the issue https://github.com/aquasecurity/table/issues/28. 