### PR TITLE
feat: add rows count

### DIFF
--- a/table.go
+++ b/table.go
@@ -939,3 +939,8 @@ func (t *Table) Render() {
 func (t *Table) IsEmpty() bool {
 	return len(t.data) == 0
 }
+
+// RowCount returns the number of rows in the table.
+func (t *Table) RowCount() int {
+	return len(t.data)
+}

--- a/table_test.go
+++ b/table_test.go
@@ -830,3 +830,13 @@ func Test_TableIsNotEmpty(t *testing.T) {
 	table.AddRow("4", "5", "6")
 	assert.Equal(t, false, table.IsEmpty())
 }
+
+func Test_TableRowCount(t *testing.T) {
+	builder := &strings.Builder{}
+	table := New(builder)
+	table.SetHeaders("A", "B", "C")
+	assert.Equal(t, 0, table.RowCount())
+	table.AddRow("1", "2", "3")
+	table.AddRow("4", "5", "6")
+	assert.Equal(t, 2, table.RowCount())
+}


### PR DESCRIPTION
Add a public method to count the number of rows in the table.

##### Example:

```golang
numberOfRows := t.RowCount()
if numberOfRows == len(arguments) {
    // do something
}
```

This PR refers to the issue https://github.com/aquasecurity/table/issues/30.