### PR TITLE
feat: add method to clear the table

### DIFF
--- a/table.go
+++ b/table.go
@@ -945,3 +945,8 @@ func (t *Table) IsEmpty() bool {
 func (t *Table) RowCount() int {
 	return len(t.data)
 }
+
+// Clear clears the table data
+func (t *Table) Clear() {
+	t.data = nil
+}

--- a/table_test.go
+++ b/table_test.go
@@ -860,3 +860,15 @@ func Test_TableRowCount(t *testing.T) {
 	table.AddRow("4", "5", "6")
 	assert.Equal(t, 2, table.RowCount())
 }
+
+func Test_ClearTable(t *testing.T) {
+	builder := &strings.Builder{}
+	table := New(builder)
+	table.SetHeaders("A", "B", "C")
+	assert.Equal(t, true, table.IsEmpty())
+	table.AddRow("1", "2", "3")
+	table.AddRow("4", "5", "6")
+	assert.Equal(t, false, table.IsEmpty())
+	table.Clear()
+	assert.Equal(t, true, table.IsEmpty())
+}


### PR DESCRIPTION
Add a method to clear the table. It does not clear the header.

##### Example:

```golang
t := table.New(os.Stdout)
t.SetHeaders("A", "B", "C")
t.AddRow("1", "2", "3")
t.AddRow("4", "5", "6")
t.Clear()
```

This PR refers to the issue https://github.com/aquasecurity/table/issues/25.